### PR TITLE
Fixed Python 3.12 Bug, MatModOps Simplified

### DIFF
--- a/mrg32k3a/matmodops.py
+++ b/mrg32k3a/matmodops.py
@@ -1,20 +1,25 @@
 #!/usr/bin/env python
 """Useful matrix/modulus operations for mrg32k3a generator."""
 
+import numpy as np
 
-def mat33_mat31_mult(a: list[list[float]], b: list[float]) -> list[float]:
+
+def mat33_mat31_mult(
+    a: list[list[int]] | np.ndarray,
+    b: list[int] | np.ndarray | tuple[int, int, int],
+) -> list[int]:
     """Multiply a 3 x 3 matrix with a 3 x 1 matrix.
 
     Parameters
     ----------
-    a : list [list [float]]
+    a : list[list[int]] | np.ndarray
         3 x 3 matrix.
-    b : list [float]
+    b : list[int] | np.ndarray | tuple[int, int, int]
         3 x 1 matrix.
 
     Returns
     -------
-    list [float]
+    list[int]
         3 x 1 matrix.
 
     """
@@ -26,20 +31,21 @@ def mat33_mat31_mult(a: list[list[float]], b: list[float]) -> list[float]:
 
 
 def mat33_mat33_mult(
-    a: list[list[float]], b: list[list[float]]
-) -> list[list[float]]:
+    a: list[list[int]] | np.ndarray,
+    b: list[list[int]] | np.ndarray,
+) -> list[list[int]]:
     """Multiply a 3 x 3 matrix with a 3 x 3 matrix.
 
     Parameters
     ----------
-    a : list [list [float]]
+    a : list[list[int]] | np.ndarray
         3 x 3 matrix.
-    b : list [list [float]]
+    b : list[list[int]] | np.ndarray
         3 x 3 matrix.
 
     Returns
     -------
-    list [float]
+    list[list[int]]
         3 x 3 matrix.
 
     """
@@ -51,44 +57,41 @@ def mat33_mat33_mult(
     return res
 
 
-def mat31_mod(b: list[float], m: float) -> list[float]:
+def mat31_mod(b: list[int], m: float) -> list[int]:
     """Compute moduli of a 3 x 1 matrix.
 
     Parameters
     ----------
-    b : list [float]
+    b : list[int]
         3 x 1 matrix.
     m : float
         Modulus.
 
     Returns
     -------
-    list [float]
+    list[int]
         3 x 1 matrix.
 
     """
     res = [0, 0, 0]
     for i in range(3):
-        res[i] = int(b[i] - int(b[i] / m) * m)
-        # if negative, add back modulus m
-        if res[i] < 0:
-            res[i] += m
+        res[i] = int(b[i] % m)
     return res
 
 
-def mat33_mod(a: list[float], m: float) -> list[float]:
+def mat33_mod(a: list[list[int]], m: float) -> list[list[int]]:
     """Compute moduli of a 3 x 3 matrix.
 
     Parameters
     ----------
-    a : list [float]
+    a : list[list[int]]
         3 x 3 matrix.
     m : float
         Modulus.
 
     Returns
     -------
-    list [float]
+    list[list[int]]
         3 x 3 matrix.
 
     """
@@ -96,30 +99,29 @@ def mat33_mod(a: list[float], m: float) -> list[float]:
     r3 = range(3)
     for i in r3:
         for j in r3:
-            res[i][j] = int(a[i][j] - int(a[i][j] / m) * m)
-            # if negative, add back modulus m
-            if res[i][j] < 0:
-                res[i][j] += m
+            res[i][j] = int(a[i][j] % m)
     return res
 
 
 def mat33_mat33_mod(
-    a: list[list[float]], b: list[list[float]], m: float
-) -> list[list[float]]:
+    a: list[list[int]] | np.ndarray,
+    b: list[list[int]] | np.ndarray,
+    m: float,
+) -> list[list[int]]:
     """Compute moduli of a 3 x 3 matrix x 3 x 3 matrix product.
 
     Parameters
     ----------
-    a : list [list [float]]
+    a : list[list[int]] | np.ndarray
         3 x 3 matrix.
-    b : list [list [float]]
+    b : list[list[int]] | np.ndarray
         3 x 3 matrix.
     m : float
         Modulus.
 
     Returns
     -------
-    list [list [float]]
+    list[list[int]]
         3 x 3 matrix.
 
     """
@@ -129,15 +131,15 @@ def mat33_mat33_mod(
 
 
 def mat33_power_mod(
-    a: list[list[float]], j: int, m: float
-) -> list[list[float]]:
+    a: list[list[int]] | np.ndarray, j: int, m: float
+) -> list[list[int]]:
     """Compute moduli of a 3 x 3 matrix power.
 
     Use divide-and-conquer algorithm described in L'Ecuyer (1990).
 
     Parameters
     ----------
-    a : list [list [float]]
+    a : list[list[int]] | np.ndarray
         3 x 3 matrix.
     j : int
         Exponent.
@@ -146,7 +148,7 @@ def mat33_power_mod(
 
     Returns
     -------
-    res : list [list [float]]
+    res : list[list[int]]
         3 x 3 matrix.
 
     """

--- a/mrg32k3a/matmodops.py
+++ b/mrg32k3a/matmodops.py
@@ -1,60 +1,57 @@
 #!/usr/bin/env python
-"""
-Summary
--------
-Useful matrix/modulus operations for mrg32k3a generator.
-"""
+"""Useful matrix/modulus operations for mrg32k3a generator."""
 
 
-def mat33_mat31_mult(A, b):
+def mat33_mat31_mult(a: list[list[float]], b: list[float]) -> list[float]:
     """Multiply a 3 x 3 matrix with a 3 x 1 matrix.
 
     Parameters
     ----------
-    A : list [list [float]]
+    a : list [list [float]]
         3 x 3 matrix.
     b : list [float]
         3 x 1 matrix.
 
     Returns
     -------
-    res : list [float]
+    list [float]
         3 x 1 matrix.
+
     """
     res = [0, 0, 0]
     r3 = range(3)
     for i in r3:
-        res[i] = sum([A[i][j] * b[j] for j in r3])
+        res[i] = sum([a[i][j] * b[j] for j in r3])
     return res
 
 
-def mat33_mat33_mult(A, B):
+def mat33_mat33_mult(
+    a: list[list[float]], b: list[list[float]]
+) -> list[list[float]]:
     """Multiply a 3 x 3 matrix with a 3 x 3 matrix.
 
     Parameters
     ----------
-    A : list [list [float]]
+    a : list [list [float]]
         3 x 3 matrix.
-    B : list [list [float]]
+    b : list [list [float]]
         3 x 3 matrix.
 
     Returns
     -------
-    res : list [float]
+    list [float]
         3 x 3 matrix.
+
     """
-    res = [[0, 0, 0],
-           [0, 0, 0],
-           [0, 0, 0]
-           ]
+    res = [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
     r3 = range(3)
     for i in r3:
         for j in r3:
-            res[i][j] = sum([A[i][k] * B[k][j] for k in r3])
+            res[i][j] = sum([a[i][k] * b[k][j] for k in r3])
     return res
 
 
-def mat31_mod(b, m):
+def mat31_mod(b: list[float], m: float) -> list[float]:
     """Compute moduli of a 3 x 1 matrix.
 
     Parameters
@@ -66,8 +63,9 @@ def mat31_mod(b, m):
 
     Returns
     -------
-    res : list [float]
+    list [float]
         3 x 1 matrix.
+
     """
     res = [0, 0, 0]
     for i in range(3):
@@ -78,64 +76,68 @@ def mat31_mod(b, m):
     return res
 
 
-def mat33_mod(A, m):
+def mat33_mod(a: list[float], m: float) -> list[float]:
     """Compute moduli of a 3 x 3 matrix.
 
     Parameters
     ----------
-    A : list [float]
+    a : list [float]
         3 x 3 matrix.
     m : float
         Modulus.
 
     Returns
     -------
-    res : list [float]
+    list [float]
         3 x 3 matrix.
+
     """
-    res = [[0, 0, 0],
-           [0, 0, 0],
-           [0, 0, 0]
-           ]
+    res = [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
     r3 = range(3)
     for i in r3:
         for j in r3:
-            res[i][j] = int(A[i][j] - int(A[i][j] / m) * m)
+            res[i][j] = int(a[i][j] - int(a[i][j] / m) * m)
             # if negative, add back modulus m
             if res[i][j] < 0:
                 res[i][j] += m
     return res
 
 
-def mat33_mat33_mod(A, B, m):
+def mat33_mat33_mod(
+    a: list[list[float]], b: list[list[float]], m: float
+) -> list[list[float]]:
     """Compute moduli of a 3 x 3 matrix x 3 x 3 matrix product.
 
     Parameters
     ----------
-    A : list [list [float]]
+    a : list [list [float]]
         3 x 3 matrix.
-    B : list [list [float]]
+    b : list [list [float]]
         3 x 3 matrix.
     m : float
         Modulus.
 
     Returns
     -------
-    res : list [list [float]]
+    list [list [float]]
         3 x 3 matrix.
+
     """
-    C = mat33_mat33_mult(A, B)
-    res = mat33_mod(C, m)
+    c = mat33_mat33_mult(a, b)
+    res = mat33_mod(c, m)
     return res
 
 
-def mat33_power_mod(A, j, m):
+def mat33_power_mod(
+    a: list[list[float]], j: int, m: float
+) -> list[list[float]]:
     """Compute moduli of a 3 x 3 matrix power.
+
     Use divide-and-conquer algorithm described in L'Ecuyer (1990).
 
     Parameters
     ----------
-    A : list [list [float]]
+    a : list [list [float]]
         3 x 3 matrix.
     j : int
         Exponent.
@@ -146,15 +148,13 @@ def mat33_power_mod(A, j, m):
     -------
     res : list [list [float]]
         3 x 3 matrix.
+
     """
-    B = [[1, 0, 0],
-         [0, 1, 0],
-         [0, 0, 1]
-         ]
+    b = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
     while j > 0:
-        if (j % 2 == 1):
-            B = mat33_mat33_mod(A, B, m)
-        A = mat33_mat33_mod(A, A, m)
+        if j % 2 == 1:
+            b = mat33_mat33_mod(a, b, m)
+        a = mat33_mat33_mod(a, a, m)
         j = int(j / 2)
-    res = B
+    res = b
     return res

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mrg32k3a"
-version = "1.0.0"
+version = "1.0.1"
 authors = [
   { name="David Eckman", email="eckman@tamu.edu" },
   { name="Shane Henderson", email="sgh9@cornell.edu" },

--- a/tests/test_matmodops.py
+++ b/tests/test_matmodops.py
@@ -2,12 +2,10 @@
 
 import os
 import sys
-sys.path.insert(0, os.path.abspath('..'))
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
 import unittest
-
-from src.mrg32k3a.matmodops import *
-
+import mrg32k3a.matmodops as mrg_mmo
 
 A = [[1, 2, 3],
      [4, 5, 6],
@@ -25,34 +23,34 @@ m = 3
 class TestMatModOps(unittest.TestCase):
 
     def test_mat33_mat31_mult(self):
-        self.assertEqual(mat33_mat31_mult(A, b), [14, 32, 50])
+        self.assertEqual(mrg_mmo.mat33_mat31_mult(A, b), [14, 32, 50])
 
     def test_mat33_mat33_mult(self):
-        self.assertEqual(mat33_mat33_mult(A, A), [[30, 36, 42], [66, 81, 96], [102, 126, 150]])
+        self.assertEqual(mrg_mmo.mat33_mat33_mult(A, A), [[30, 36, 42], [66, 81, 96], [102, 126, 150]])
 
     def test_mat31_mod(self):
-        self.assertEqual(mat31_mod(b, m), [1, 2, 0])
+        self.assertEqual(mrg_mmo.mat31_mod(b, m), [1, 2, 0])
 
     def test_mat31_mod_neg(self):
-        self.assertEqual(mat31_mod(bneg, m), [2, 1, 0])
+        self.assertEqual(mrg_mmo.mat31_mod(bneg, m), [2, 1, 0])
 
     def test_mat33_mod(self):
-        self.assertEqual(mat33_mod(A, m), [[1, 2, 0], [1, 2, 0], [1, 2, 0]])
+        self.assertEqual(mrg_mmo.mat33_mod(A, m), [[1, 2, 0], [1, 2, 0], [1, 2, 0]])
 
     def test_mat33_mod_neg(self):
-        self.assertEqual(mat33_mod(Aneg, m), [[2, 1, 0], [2, 1, 0], [2, 1, 0]])
+        self.assertEqual(mrg_mmo.mat33_mod(Aneg, m), [[2, 1, 0], [2, 1, 0], [2, 1, 0]])
 
     def test_mat33_mat33_mod(self):
-        self.assertEqual(mat33_mat33_mod(A, A, m), [[0, 0, 0], [0, 0, 0], [0, 0, 0]])
+        self.assertEqual(mrg_mmo.mat33_mat33_mod(A, A, m), [[0, 0, 0], [0, 0, 0], [0, 0, 0]])
 
     def test_mat33_power_mod_power0(self):
-        self.assertEqual(mat33_power_mod(A, 0, m), [[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+        self.assertEqual(mrg_mmo.mat33_power_mod(A, 0, m), [[1, 0, 0], [0, 1, 0], [0, 0, 1]])
 
     def test_mat33_power_mod_power1(self):
-        self.assertEqual(mat33_power_mod(A, 1, m), [[1, 2, 0], [1, 2, 0], [1, 2, 0]])
+        self.assertEqual(mrg_mmo.mat33_power_mod(A, 1, m), [[1, 2, 0], [1, 2, 0], [1, 2, 0]])
 
     def test_mat33_power_mod_power2(self):
-        self.assertEqual(mat33_power_mod(A, 2, m), [[0, 0, 0], [0, 0, 0], [0, 0, 0]])
+        self.assertEqual(mrg_mmo.mat33_power_mod(A, 2, m), [[0, 0, 0], [0, 0, 0], [0, 0, 0]])
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_matmodops.py
+++ b/tests/test_matmodops.py
@@ -2,31 +2,28 @@
 
 import os
 import sys
-sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
-
 import unittest
+
 import mrg32k3a.matmodops as mrg_mmo
 
-A = [[1, 2, 3],
-     [4, 5, 6],
-     [7, 8, 9]
-     ]
-Aneg = [[-1, -2, -3],
-        [-4, -5, -6],
-        [-7, -8, -9]
-        ]
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+A = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+Aneg = [[-1, -2, -3], [-4, -5, -6], [-7, -8, -9]]
 b = [1, 2, 3]
 bneg = [-1, -2, -3]
 m = 3
 
 
 class TestMatModOps(unittest.TestCase):
-
     def test_mat33_mat31_mult(self):
         self.assertEqual(mrg_mmo.mat33_mat31_mult(A, b), [14, 32, 50])
 
     def test_mat33_mat33_mult(self):
-        self.assertEqual(mrg_mmo.mat33_mat33_mult(A, A), [[30, 36, 42], [66, 81, 96], [102, 126, 150]])
+        self.assertEqual(
+            mrg_mmo.mat33_mat33_mult(A, A),
+            [[30, 36, 42], [66, 81, 96], [102, 126, 150]],
+        )
 
     def test_mat31_mod(self):
         self.assertEqual(mrg_mmo.mat31_mod(b, m), [1, 2, 0])
@@ -41,16 +38,25 @@ class TestMatModOps(unittest.TestCase):
         self.assertEqual(mrg_mmo.mat33_mod(Aneg, m), [[2, 1, 0], [2, 1, 0], [2, 1, 0]])
 
     def test_mat33_mat33_mod(self):
-        self.assertEqual(mrg_mmo.mat33_mat33_mod(A, A, m), [[0, 0, 0], [0, 0, 0], [0, 0, 0]])
+        self.assertEqual(
+            mrg_mmo.mat33_mat33_mod(A, A, m), [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
+        )
 
     def test_mat33_power_mod_power0(self):
-        self.assertEqual(mrg_mmo.mat33_power_mod(A, 0, m), [[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+        self.assertEqual(
+            mrg_mmo.mat33_power_mod(A, 0, m), [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
+        )
 
     def test_mat33_power_mod_power1(self):
-        self.assertEqual(mrg_mmo.mat33_power_mod(A, 1, m), [[1, 2, 0], [1, 2, 0], [1, 2, 0]])
+        self.assertEqual(
+            mrg_mmo.mat33_power_mod(A, 1, m), [[1, 2, 0], [1, 2, 0], [1, 2, 0]]
+        )
 
     def test_mat33_power_mod_power2(self):
-        self.assertEqual(mrg_mmo.mat33_power_mod(A, 2, m), [[0, 0, 0], [0, 0, 0], [0, 0, 0]])
+        self.assertEqual(
+            mrg_mmo.mat33_power_mod(A, 2, m), [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
+        )
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_mrg32k3a.py
+++ b/tests/test_mrg32k3a.py
@@ -2,12 +2,11 @@
 
 import os
 import sys
-sys.path.insert(0, os.path.abspath('..'))
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
 import unittest
-
-from src.mrg32k3a.mrg32k3a import *
-from src.mrg32k3a.matmodops import mat33_mat33_mult
+import mrg32k3a.mrg32k3a as mrg
+import mrg32k3a.matmodops as mrg_mmo
 
 A1p127 = [[2427906178, 3580155704, 949770784],
           [226153695, 1230515664, 3580155704],
@@ -35,72 +34,82 @@ seed = (12345, 12345, 12345, 12345, 12345, 12345)
 class TestMRG32k3a(unittest.TestCase):
 
     def test_A1p127(self):
-        self.assertEqual(mat33_power_mod(A1p0, 2**127, mrgm1), A1p127)
+        self.assertEqual(mrg_mmo.mat33_power_mod(mrg.A1p0, 2**127, mrg.mrgm1), A1p127)
 
     def test_A2p127(self):
-        self.assertEqual(mat33_power_mod(A2p0, 2**127, mrgm2), A2p127)
+        self.assertEqual(mrg_mmo.mat33_power_mod(mrg.A2p0, 2**127, mrg.mrgm2), A2p127)
 
     def test_A1p76(self):
-        self.assertEqual(mat33_power_mod(A1p0, 2**76, mrgm1), A1p76)
+        self.assertEqual(mrg_mmo.mat33_power_mod(mrg.A1p0, 2**76, mrg.mrgm1), A1p76)
 
     def test_A2p76(self):
-        self.assertEqual(mat33_power_mod(A2p0, 2**76, mrgm2), A2p76)
+        self.assertEqual(mrg_mmo.mat33_power_mod(mrg.A2p0, 2**76, mrg.mrgm2), A2p76)
 
     def test_A1p47(self):
-        self.assertEqual(mat33_power_mod(A1p0, 2**47, mrgm1), A1p47)
+        self.assertEqual(mrg_mmo.mat33_power_mod(mrg.A1p0, 2**47, mrg.mrgm1), mrg.A1p47.tolist())
 
     def test_A2p47(self):
-        self.assertEqual(mat33_power_mod(A2p0, 2**47, mrgm2), A2p47)
+        self.assertEqual(mrg_mmo.mat33_power_mod(mrg.A2p0, 2**47, mrg.mrgm2), mrg.A2p47.tolist())
 
     def test_A1p94(self):
-        self.assertEqual(mat33_power_mod(A1p0, 2**94, mrgm1), A1p94)
+        self.assertEqual(mrg_mmo.mat33_power_mod(mrg.A1p0, 2**94, mrg.mrgm1), mrg.A1p94.tolist())
 
     def test_A2p94(self):
-        self.assertEqual(mat33_power_mod(A2p0, 2**94, mrgm2), A2p94)
+        self.assertEqual(mrg_mmo.mat33_power_mod(mrg.A2p0, 2**94, mrg.mrgm2), mrg.A2p94.tolist())
 
     def test_A1p141(self):
-        self.assertEqual(mat33_power_mod(A1p0, 2**141, mrgm1), A1p141)
+        self.assertEqual(mrg_mmo.mat33_power_mod(mrg.A1p0, 2**141, mrg.mrgm1), mrg.A1p141.tolist())
 
     def test_A2p141(self):
-        self.assertEqual(mat33_power_mod(A2p0, 2**141, mrgm2), A2p141)
+        self.assertEqual(mrg_mmo.mat33_power_mod(mrg.A2p0, 2**141, mrg.mrgm2), mrg.A2p141.tolist())
 
     def test_get_current_state(self):
-        rng = MRG32k3a()
+        rng = mrg.MRG32k3a()
         self.assertEqual(rng.get_current_state(), seed)
 
     def test_first_state(self):
-        rng = MRG32k3a()
+        rng = mrg.MRG32k3a()
         self.assertEqual(rng._current_state, seed)
 
     def test_second_state(self):
-        rng = MRG32k3a()
+        rng = mrg.MRG32k3a()
         rng.random()
-        st1 = mat31_mod(mat33_mat31_mult(A1p0, seed[0:3]), mrgm1)
-        st2 = mat31_mod(mat33_mat31_mult(A2p0, seed[3:6]), mrgm2)
+        st1 = mrg_mmo.mat31_mod(mrg_mmo.mat33_mat31_mult(mrg.A1p0, seed[0:3]), mrg.mrgm1)
+        st2 = mrg_mmo.mat31_mod(mrg_mmo.mat33_mat31_mult(mrg.A2p0, seed[3:6]), mrg.mrgm2)
         self.assertSequenceEqual(rng._current_state, st1 + st2)
 
     def test_third_state(self):
-        rng = MRG32k3a()
+        rng = mrg.MRG32k3a()
         rng.random()
         rng.random()
-        A1sq = mat33_mat33_mult(A1p0, A1p0)
-        A2sq = mat33_mat33_mult(A2p0, A2p0)
-        st1 = mat31_mod(mat33_mat31_mult(A1sq, seed[0:3]), mrgm1)
-        st2 = mat31_mod(mat33_mat31_mult(A2sq, seed[3:6]), mrgm2)
+        A1sq = mrg_mmo.mat33_mat33_mult(mrg.A1p0, mrg.A1p0)
+        A2sq = mrg_mmo.mat33_mat33_mult(mrg.A2p0, mrg.A2p0)
+        st1 = mrg_mmo.mat31_mod(mrg_mmo.mat33_mat31_mult(A1sq, seed[0:3]), mrg.mrgm1)
+        st2 = mrg_mmo.mat31_mod(mrg_mmo.mat33_mat31_mult(A2sq, seed[3:6]), mrg.mrgm2)
         self.assertSequenceEqual(rng._current_state, st1 + st2)
 
     def test_hundreth_state(self):
-        rng = MRG32k3a()
+        rng = mrg.MRG32k3a()
         for _ in range(99):
             rng.random()
-        st1 = mat31_mod(mat33_mat31_mult(mat33_power_mod(A1p0, 99, mrgm1), seed[0:3]), mrgm1)
-        st2 = mat31_mod(mat33_mat31_mult(mat33_power_mod(A2p0, 99, mrgm2), seed[3:6]), mrgm2)
+        power_mod_1 = mrg_mmo.mat33_power_mod(mrg.A1p0, 99, mrg.mrgm1)
+        self.assertEqual(power_mod_1, [[799720564, 1904270070, 1363680284], [2278512092, 270284082, 1904270070], [2328946625, 990418809, 270284082]])
+        multi_1 = mrg_mmo.mat33_mat31_mult(power_mod_1, seed[0:3])
+        self.assertEqual(multi_1, [50215397482710, 54973102782180, 44314223275020])
+        st1 = mrg_mmo.mat31_mod(multi_1, mrg.mrgm1)
+        self.assertEqual(st1, [2937268593, 1819035667, 3047838441])
+        power_mod_2 = mrg_mmo.mat33_power_mod(mrg.A2p0, 99, mrg.mrgm2)
+        self.assertEqual(power_mod_2, [[3836971470, 1481396816, 1475521836], [722527348, 3836971470, 2878594268], [685711492, 722527348, 2167021383]])
+        multi_2 = mrg_mmo.mat33_mat31_mult(power_mod_2, seed[3:6])
+        self.assertEqual(multi_2, [83870573556090, 91823259146670, 44136587452935])
+        st2 = mrg_mmo.mat31_mod(multi_2, mrg.mrgm2)
+        self.assertEqual(st2, [3193417629, 1641899773, 1738356667])
         self.assertSequenceEqual(rng._current_state, st1 + st2)
 
     def test_advance_stream(self):
-        rng = MRG32k3a(s_ss_sss_index=[0, 1, 1])
+        rng = mrg.MRG32k3a(s_ss_sss_index=[0, 1, 1])
         rng.advance_stream()
-        rng2 = MRG32k3a(s_ss_sss_index=[1, 0, 0])
+        rng2 = mrg.MRG32k3a(s_ss_sss_index=[1, 0, 0])
         self.assertEqual(rng._current_state, rng2._current_state)
         self.assertEqual(rng.stream_start, rng._current_state)
         self.assertEqual(rng.substream_start, rng._current_state)
@@ -108,9 +117,9 @@ class TestMRG32k3a(unittest.TestCase):
         self.assertEqual(rng.s_ss_sss_index, [1, 0, 0])
 
     def test_advance_substream(self):
-        rng = MRG32k3a(s_ss_sss_index=[0, 0, 1])
+        rng = mrg.MRG32k3a(s_ss_sss_index=[0, 0, 1])
         rng.advance_substream()
-        rng2 = MRG32k3a(s_ss_sss_index=[0, 1, 0])
+        rng2 = mrg.MRG32k3a(s_ss_sss_index=[0, 1, 0])
         self.assertEqual(rng._current_state, rng2._current_state)
         self.assertEqual(rng.stream_start, seed)
         self.assertEqual(rng.substream_start, rng._current_state)
@@ -118,9 +127,9 @@ class TestMRG32k3a(unittest.TestCase):
         self.assertEqual(rng.s_ss_sss_index, [0, 1, 0])
 
     def test_advance_subsubstream(self):
-        rng = MRG32k3a()
+        rng = mrg.MRG32k3a()
         rng.advance_subsubstream()
-        rng2 = MRG32k3a(s_ss_sss_index=[0, 0, 1])
+        rng2 = mrg.MRG32k3a(s_ss_sss_index=[0, 0, 1])
         self.assertEqual(rng._current_state, rng2._current_state)
         self.assertEqual(rng.stream_start, seed)
         self.assertEqual(rng.substream_start, seed)
@@ -128,10 +137,10 @@ class TestMRG32k3a(unittest.TestCase):
         self.assertEqual(rng.s_ss_sss_index, [0, 0, 1])
 
     def test_reset_stream(self):
-        rng = MRG32k3a(s_ss_sss_index=[1, 1, 1])
+        rng = mrg.MRG32k3a(s_ss_sss_index=[1, 1, 1])
         rng.random()
         rng.reset_stream()
-        rng2 = MRG32k3a(s_ss_sss_index=[1, 0, 0])
+        rng2 = mrg.MRG32k3a(s_ss_sss_index=[1, 0, 0])
         self.assertEqual(rng._current_state, rng2._current_state)
         self.assertEqual(rng.stream_start, rng._current_state)
         self.assertEqual(rng.substream_start, rng._current_state)
@@ -139,33 +148,33 @@ class TestMRG32k3a(unittest.TestCase):
         self.assertEqual(rng.s_ss_sss_index, [1, 0, 0])
 
     def test_reset_substream(self):
-        rng = MRG32k3a(s_ss_sss_index=[1, 1, 1])
+        rng = mrg.MRG32k3a(s_ss_sss_index=[1, 1, 1])
         rng.random()
         rng.reset_substream()
-        rng2 = MRG32k3a(s_ss_sss_index=[1, 1, 0])
+        rng2 = mrg.MRG32k3a(s_ss_sss_index=[1, 1, 0])
         self.assertEqual(rng._current_state, rng2._current_state)
-        rng3 = MRG32k3a(s_ss_sss_index=[1, 0, 0])
+        rng3 = mrg.MRG32k3a(s_ss_sss_index=[1, 0, 0])
         self.assertEqual(rng.stream_start, rng3._current_state)
         self.assertEqual(rng.substream_start, rng._current_state)
         self.assertEqual(rng.subsubstream_start, rng._current_state)
         self.assertEqual(rng.s_ss_sss_index, [1, 1, 0])
 
     def test_reset_subsubstream(self):
-        rng = MRG32k3a(s_ss_sss_index=[1, 1, 1])
+        rng = mrg.MRG32k3a(s_ss_sss_index=[1, 1, 1])
         rng.random()
         rng.reset_subsubstream()
-        rng2 = MRG32k3a(s_ss_sss_index=[1, 1, 1])
+        rng2 = mrg.MRG32k3a(s_ss_sss_index=[1, 1, 1])
         self.assertEqual(rng._current_state, rng2._current_state)
-        rng3 = MRG32k3a(s_ss_sss_index=[1, 0, 0])
-        rng4 = MRG32k3a(s_ss_sss_index=[1, 1, 0])
+        rng3 = mrg.MRG32k3a(s_ss_sss_index=[1, 0, 0])
+        rng4 = mrg.MRG32k3a(s_ss_sss_index=[1, 1, 0])
         self.assertEqual(rng.stream_start, rng3._current_state)
         self.assertEqual(rng.substream_start, rng4._current_state)
         self.assertEqual(rng.subsubstream_start, rng._current_state)
         self.assertEqual(rng.s_ss_sss_index, [1, 1, 1])
 
     def test_init_fixed_s_ss_sss(self):
-        rng = MRG32k3a(s_ss_sss_index=[1, 1, 1])
-        rng2 = MRG32k3a()
+        rng = mrg.MRG32k3a(s_ss_sss_index=[1, 1, 1])
+        rng2 = mrg.MRG32k3a()
         rng2.start_fixed_s_ss_sss([1, 1, 1])
         self.assertEqual(rng._current_state, rng2._current_state)
         self.assertEqual(rng.stream_start, rng2.stream_start)
@@ -174,9 +183,9 @@ class TestMRG32k3a(unittest.TestCase):
         self.assertEqual(rng.s_ss_sss_index, rng2.s_ss_sss_index)
 
     def test_jump_fixed_s_ss_sss(self):
-        rng = MRG32k3a()
+        rng = mrg.MRG32k3a()
         rng.start_fixed_s_ss_sss([1, 1, 1])
-        rng2 = MRG32k3a()
+        rng2 = mrg.MRG32k3a()
         rng2.advance_stream()
         rng2.advance_substream()
         rng2.advance_subsubstream()

--- a/tests/test_mrg32k3a.py
+++ b/tests/test_mrg32k3a.py
@@ -2,37 +2,42 @@
 
 import os
 import sys
-sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
-
 import unittest
-import mrg32k3a.mrg32k3a as mrg
+
 import mrg32k3a.matmodops as mrg_mmo
+import mrg32k3a.mrg32k3a as mrg
 
-A1p127 = [[2427906178, 3580155704, 949770784],
-          [226153695, 1230515664, 3580155704],
-          [1988835001,  986791581, 1230515664]
-          ]
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
-A2p127 = [[1464411153,  277697599, 1610723613],
-          [32183930, 1464411153.0, 1022607788],
-          [2824425944, 32183930.0, 2093834863]
-          ]
 
-A1p76 = [[82758667, 1871391091, 4127413238],
-         [3672831523, 69195019, 1871391091],
-         [3672091415, 3528743235, 69195019]
-         ]
+A1p127 = [
+    [2427906178, 3580155704, 949770784],
+    [226153695, 1230515664, 3580155704],
+    [1988835001, 986791581, 1230515664],
+]
 
-A2p76 = [[1511326704, 3759209742, 1610795712],
-         [4292754251, 1511326704, 3889917532],
-         [3859662829, 4292754251, 3708466080],
-         ]
+A2p127 = [
+    [1464411153, 277697599, 1610723613],
+    [32183930, 1464411153.0, 1022607788],
+    [2824425944, 32183930.0, 2093834863],
+]
+
+A1p76 = [
+    [82758667, 1871391091, 4127413238],
+    [3672831523, 69195019, 1871391091],
+    [3672091415, 3528743235, 69195019],
+]
+
+A2p76 = [
+    [1511326704, 3759209742, 1610795712],
+    [4292754251, 1511326704, 3889917532],
+    [3859662829, 4292754251, 3708466080],
+]
 
 seed = (12345, 12345, 12345, 12345, 12345, 12345)
 
 
 class TestMRG32k3a(unittest.TestCase):
-
     def test_A1p127(self):
         self.assertEqual(mrg_mmo.mat33_power_mod(mrg.A1p0, 2**127, mrg.mrgm1), A1p127)
 
@@ -46,22 +51,34 @@ class TestMRG32k3a(unittest.TestCase):
         self.assertEqual(mrg_mmo.mat33_power_mod(mrg.A2p0, 2**76, mrg.mrgm2), A2p76)
 
     def test_A1p47(self):
-        self.assertEqual(mrg_mmo.mat33_power_mod(mrg.A1p0, 2**47, mrg.mrgm1), mrg.A1p47.tolist())
+        self.assertEqual(
+            mrg_mmo.mat33_power_mod(mrg.A1p0, 2**47, mrg.mrgm1), mrg.A1p47.tolist()
+        )
 
     def test_A2p47(self):
-        self.assertEqual(mrg_mmo.mat33_power_mod(mrg.A2p0, 2**47, mrg.mrgm2), mrg.A2p47.tolist())
+        self.assertEqual(
+            mrg_mmo.mat33_power_mod(mrg.A2p0, 2**47, mrg.mrgm2), mrg.A2p47.tolist()
+        )
 
     def test_A1p94(self):
-        self.assertEqual(mrg_mmo.mat33_power_mod(mrg.A1p0, 2**94, mrg.mrgm1), mrg.A1p94.tolist())
+        self.assertEqual(
+            mrg_mmo.mat33_power_mod(mrg.A1p0, 2**94, mrg.mrgm1), mrg.A1p94.tolist()
+        )
 
     def test_A2p94(self):
-        self.assertEqual(mrg_mmo.mat33_power_mod(mrg.A2p0, 2**94, mrg.mrgm2), mrg.A2p94.tolist())
+        self.assertEqual(
+            mrg_mmo.mat33_power_mod(mrg.A2p0, 2**94, mrg.mrgm2), mrg.A2p94.tolist()
+        )
 
     def test_A1p141(self):
-        self.assertEqual(mrg_mmo.mat33_power_mod(mrg.A1p0, 2**141, mrg.mrgm1), mrg.A1p141.tolist())
+        self.assertEqual(
+            mrg_mmo.mat33_power_mod(mrg.A1p0, 2**141, mrg.mrgm1), mrg.A1p141.tolist()
+        )
 
     def test_A2p141(self):
-        self.assertEqual(mrg_mmo.mat33_power_mod(mrg.A2p0, 2**141, mrg.mrgm2), mrg.A2p141.tolist())
+        self.assertEqual(
+            mrg_mmo.mat33_power_mod(mrg.A2p0, 2**141, mrg.mrgm2), mrg.A2p141.tolist()
+        )
 
     def test_get_current_state(self):
         rng = mrg.MRG32k3a()
@@ -74,8 +91,12 @@ class TestMRG32k3a(unittest.TestCase):
     def test_second_state(self):
         rng = mrg.MRG32k3a()
         rng.random()
-        st1 = mrg_mmo.mat31_mod(mrg_mmo.mat33_mat31_mult(mrg.A1p0, seed[0:3]), mrg.mrgm1)
-        st2 = mrg_mmo.mat31_mod(mrg_mmo.mat33_mat31_mult(mrg.A2p0, seed[3:6]), mrg.mrgm2)
+        st1 = mrg_mmo.mat31_mod(
+            mrg_mmo.mat33_mat31_mult(mrg.A1p0, seed[0:3]), mrg.mrgm1
+        )
+        st2 = mrg_mmo.mat31_mod(
+            mrg_mmo.mat33_mat31_mult(mrg.A2p0, seed[3:6]), mrg.mrgm2
+        )
         self.assertSequenceEqual(rng._current_state, st1 + st2)
 
     def test_third_state(self):
@@ -93,13 +114,27 @@ class TestMRG32k3a(unittest.TestCase):
         for _ in range(99):
             rng.random()
         power_mod_1 = mrg_mmo.mat33_power_mod(mrg.A1p0, 99, mrg.mrgm1)
-        self.assertEqual(power_mod_1, [[799720564, 1904270070, 1363680284], [2278512092, 270284082, 1904270070], [2328946625, 990418809, 270284082]])
+        self.assertEqual(
+            power_mod_1,
+            [
+                [799720564, 1904270070, 1363680284],
+                [2278512092, 270284082, 1904270070],
+                [2328946625, 990418809, 270284082],
+            ],
+        )
         multi_1 = mrg_mmo.mat33_mat31_mult(power_mod_1, seed[0:3])
         self.assertEqual(multi_1, [50215397482710, 54973102782180, 44314223275020])
         st1 = mrg_mmo.mat31_mod(multi_1, mrg.mrgm1)
         self.assertEqual(st1, [2937268593, 1819035667, 3047838441])
         power_mod_2 = mrg_mmo.mat33_power_mod(mrg.A2p0, 99, mrg.mrgm2)
-        self.assertEqual(power_mod_2, [[3836971470, 1481396816, 1475521836], [722527348, 3836971470, 2878594268], [685711492, 722527348, 2167021383]])
+        self.assertEqual(
+            power_mod_2,
+            [
+                [3836971470, 1481396816, 1475521836],
+                [722527348, 3836971470, 2878594268],
+                [685711492, 722527348, 2167021383],
+            ],
+        )
         multi_2 = mrg_mmo.mat33_mat31_mult(power_mod_2, seed[3:6])
         self.assertEqual(multi_2, [83870573556090, 91823259146670, 44136587452935])
         st2 = mrg_mmo.mat31_mod(multi_2, mrg.mrgm2)
@@ -195,5 +230,6 @@ class TestMRG32k3a(unittest.TestCase):
         self.assertEqual(rng.subsubstream_start, rng2.subsubstream_start)
         self.assertEqual(rng.s_ss_sss_index, rng2.s_ss_sss_index)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# Fixed Python 3.12 Bug
- Starting in Python 3.12, the built-in sum() function adds error correction when summing floats. While more accurate, this can cause sums to differ from prior Python versions. The bsm() function in particular was subject to differing results, causing major discrepancies in programs that used it for random generation.

# mrg32k3a No Longer Depends on matmodops
madmodops contained several operations to perform matrix calculations on nested lists. By redefining mrg32k3a to use NumPy arrays internally instead of lists, the program can now leverage NumPy's optimized implementation of matrix multiplication (using the @ operator) and modulus division (using the % operand). matmodops was not removed for possible legacy support reasons.

# File Structure Reorganization
Inclusion of a "src" folder is not recommended in Python for being unpythonic. Each file in the `mrg32k3a/src/mrg32k3a` folder was moved to `mrg32k3a/mrg32k3a'. I don't believe this should cause any issues with programs using mrg32k3a as a dependency.

# Added Typing
Added typing to all methods in matmodops and mrg32k3a

# Remove Asterisk Imports
Using an asterisk to import an entire module is considered bad practice in Python. I went ahead and moved all * imports to 'import as' imports, eliminating the possibility of conflicting methods.